### PR TITLE
Fix publishing to Ansible Galaxy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,8 @@
 name: molecule
 
 on:
-  schedule:    - cron: '* 1 * * 1'
+  schedule:
+    - cron: '* 1 * * 1'
   push:
     branches:
       - master
@@ -40,4 +41,4 @@ jobs:
         if: github.event_name == 'push'
         uses: robertdebock/galaxy-action@1.0.3
         with:
-          galaxy_api_key: ${{ secrets.galaxy_api_key }}
+          galaxy_api_key: ${{ secrets.GALAXY_API_KEY }}


### PR DESCRIPTION
The issue lies in a single secret variable that was spelled with a non-capital letter.

The error should've been displayed in the log, but wasn't.

This fixes the issue #1