### PR TITLE
Fix missing become on optimus support install and a missing dash for ubuntu-drivers command

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,6 +35,7 @@
 
 - name: add optimus support
   when: nvidia_cuda_add_optimus_support
+  become: true
   package:
     name: bumblebee-nvidia
     state: present

--- a/tasks/nvidia_driver.yml
+++ b/tasks/nvidia_driver.yml
@@ -24,7 +24,7 @@
     - ubuntu_drivers_command.rc == 0
   become: true
   command:
-    cmd: ubuntu-drivers install -gpgpu
+    cmd: "ubuntu-drivers install --gpgpu"
   tags: install
 
 - name: establish nvidia driver


### PR DESCRIPTION
Bugs:
* a single become was missing for nvidia driver install from ubuntu
* a single dash was missing for nvidia driver install using the ubuntu-drivers